### PR TITLE
Fix issue link for game submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Collection of Defold games. The games are listed in `games` and used by the [Showcase page on the Defold website](https://www.defold.com/showcase) and [Games page on the Defold website](https://www.defold.com/games).
 
 ## Submitting a game
-Submit a new game for inclusion in this collection either via the `Submit Game` button on the Showcase/Games page or by [Creating an Issue](https://github.com/defold/awesome-defold/issues/new?assignees=&labels=&template=new-game.md&title=).
+Submit a new game for inclusion in this collection either via the `Submit Game` button on the Showcase/Games page or by [Creating an Issue](https://github.com/defold/games-showcase/issues/new?assignees=&labels=&template=new-game.md&title=).
 
 ## Updating a game
 You can update a game by modifying its metadata file. The metadata for all assets can be found in the `games` folder of this repository. Once you are happy with the changes please submit a pull request.


### PR DESCRIPTION
Currently the link is pointing to the defold-assets issues instead of creating an issue in games-showcase. This might be confusing.